### PR TITLE
Be more lenient in supported memoryTypeFlags

### DIFF
--- a/vector_add/vector_add.cpp
+++ b/vector_add/vector_add.cpp
@@ -1,5 +1,6 @@
 #include <vulkan/vulkan.h>
 
+#include <cassert>
 #include <cstdio>
 #include <vector>
 
@@ -31,10 +32,13 @@ std::vector<char> loadShaderCode(const char *filename) {
 int32_t findMemoryTypeFromProperties(
     uint32_t memoryTypeBits, VkPhysicalDeviceMemoryProperties properties,
     VkMemoryPropertyFlags requiredProperties) {
-  for (int32_t index = 0; index < properties.memoryTypeCount; ++index) {
-    if (memoryTypeBits & (1 << index) &&
-        (properties.memoryTypes[index].propertyFlags == requiredProperties)) {
-      return index;
+  assert(properties.memoryTypeCount < 32u);
+  for (uint32_t index = 0; index < properties.memoryTypeCount; ++index) {
+    if (memoryTypeBits & (1u << index) &&
+        // Find the first memory type that supports all the required flags.
+        ((properties.memoryTypes[index].propertyFlags & requiredProperties) ==
+         requiredProperties)) {
+      return (int32_t)index;
     }
   }
   return -1;
@@ -482,7 +486,7 @@ int main() {
   dataOffset += elements;
   int32_t *resultData = data + elements;
   // now we can write our data into the memory for each input buffer
-  for (int32_t index = 0; index < elements; index++) {
+  for (uint32_t index = 0; index < elements; index++) {
     aData[index] = index;
     bData[index] = -index;
     // to ensure we are actually calculating a result we will set the result


### PR DESCRIPTION
This patch makes `findMemoryTypeFromProperties` more lenient in that it
now accepts memory types that are also superset of the requested
properties.
This fixes at least Iris Pro on mesa which has the following properties:

```
 $ vulkaninfo
 [...]
 ==================================
 GPU0
 VkPhysicalDeviceProperties:
 ===========================
         apiVersion     = 0x401000  (1.1.0)
         driverVersion  = 75501573 (0x4801005)
         vendorID       = 0x8086
         deviceID       = 0x1926
         deviceType     = INTEGRATED_GPU
         deviceName     = Intel(R) Iris Graphics 540 (Skylake GT3e)
 VkPhysicalDeviceMemoryProperties:
 =================================
 [...]
         memoryTypeCount       = 2
         memoryTypes[0] :
                 heapIndex     = 0
                 propertyFlags = 0xf:
                         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
                         VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
                         VK_MEMORY_PROPERTY_HOST_CACHED_BIT
         memoryTypes[1] :
                 heapIndex     = 1
                 propertyFlags = 0xf:
                         VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT
                         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT
                         VK_MEMORY_PROPERTY_HOST_COHERENT_BIT
                         VK_MEMORY_PROPERTY_HOST_CACHED_BIT
     },
```
Additionally fix a couple of warnings with gcc-8 which seems to be going
out of its way to make noise.